### PR TITLE
Adding Eltwise Testing

### DIFF
--- a/tensorflow/compiler/xla/service/plaidml/compiler.cc
+++ b/tensorflow/compiler/xla/service/plaidml/compiler.cc
@@ -356,18 +356,33 @@ StatusOr<std::unique_ptr<Program>> PlaidMLCompiler::ProgramFromHloModule (
           Tensor op;
           auto direction = instruction->comparison_direction();
           switch (direction) {
-            case ComparisonDirection::kEq:
+            case ComparisonDirection::kEq: {
               op = instr_map[operand_ids[0]] == instr_map[operand_ids[1]];
-            case ComparisonDirection::kNe:
+              break;
+            }
+            case ComparisonDirection::kNe: {
               op = instr_map[operand_ids[0]] != instr_map[operand_ids[1]];
-            case ComparisonDirection::kGe:
+              break;
+            }
+            case ComparisonDirection::kGe: {
               op = instr_map[operand_ids[0]] >= instr_map[operand_ids[1]];
-            case ComparisonDirection::kGt:
+              break;
+            }
+            case ComparisonDirection::kGt: {
               op = instr_map[operand_ids[0]] > instr_map[operand_ids[1]];
-            case ComparisonDirection::kLe:
+              break;
+            }
+            case ComparisonDirection::kLe: {
               op = instr_map[operand_ids[0]] <= instr_map[operand_ids[1]];
-            case ComparisonDirection::kLt:
+              break;
+            }
+            case ComparisonDirection::kLt: {
               op = instr_map[operand_ids[0]] < instr_map[operand_ids[1]];
+              break;
+            }
+            default: {
+              VLOG(2) << "Unknown comparison direction";
+            }
           }
           instr_map.insert(std::make_pair(cur_instr_id, op));
           break;

--- a/tensorflow/compiler/xla/service/plaidml/tests/BUILD
+++ b/tensorflow/compiler/xla/service/plaidml/tests/BUILD
@@ -37,6 +37,26 @@ tf_cc_test(
 )
 
 tf_cc_test(
+    name = "plaidml_logical_op_test",
+    srcs = ["plaidml_logical_op_test.cc"],
+    extra_copts = ["-fexceptions"],
+    deps = [
+        "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service/plaidml:compiler",
+        "//tensorflow/compiler/xla/service/plaidml/tests:plaidml_codegen_test",
+        "//tensorflow/compiler/xla/tests:test_utils",
+        "//tensorflow/compiler/xla/tests:hlo_test_base",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+
+tf_cc_test(
     name = "plaidml_conv_op_test",
     srcs = ["plaidml_conv_op_test.cc"],
     extra_copts = ["-fexceptions"],

--- a/tensorflow/compiler/xla/service/plaidml/tests/BUILD
+++ b/tensorflow/compiler/xla/service/plaidml/tests/BUILD
@@ -18,6 +18,25 @@ cc_library(
 )
 
 tf_cc_test(
+    name = "plaidml_compare_op_test",
+    srcs = ["plaidml_compare_op_test.cc"],
+    extra_copts = ["-fexceptions"],
+    deps = [
+        "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service/plaidml:compiler",
+        "//tensorflow/compiler/xla/service/plaidml/tests:plaidml_codegen_test",
+        "//tensorflow/compiler/xla/tests:test_utils",
+        "//tensorflow/compiler/xla/tests:hlo_test_base",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+tf_cc_test(
     name = "plaidml_eltwise_op_test",
     srcs = ["plaidml_eltwise_op_test.cc"],
     extra_copts = ["-fexceptions"],

--- a/tensorflow/compiler/xla/service/plaidml/tests/plaidml_compare_op_test.cc
+++ b/tensorflow/compiler/xla/service/plaidml/tests/plaidml_compare_op_test.cc
@@ -87,13 +87,119 @@ class PlaidMLCompareOperationTest
   }
 };
 
-TEST_P(PlaidMLCompareOperationTest, CompOp) {
+TEST_P(PlaidMLCompareOperationTest, CompEqOp) {
+  std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> B = {9, 8, 7, 6, 5, 4, 3, 2, 1};
+  std::vector<int8_t> expected_val = {0, 0, 0, 0, 1, 0, 0, 0, 0};
+  auto comp_type = ComparisonDirection::kEq;
+
+  TestCaseVal inputs = {B, A};
+  TestCaseVal_int results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("CompOp");
+  CompareTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xi1>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateCompare(param_shape, lhs, rhs, comp_type));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLCompareOperationTest, CompLtOp) {
   std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
   std::vector<float> B = {9, 8, 7, 6, 5, 4, 3, 2, 1};
   std::vector<int8_t> expected_val = {1, 1, 1, 1, 0, 0, 0, 0, 0};
-  //std::vector<int8_t> expected_val = {0, 0, 0, 0, 1, 0, 0, 0, 0};
   auto comp_type = ComparisonDirection::kLt;
-  //auto comp_type = ComparisonDirection::kEq;
+
+  TestCaseVal inputs = {B, A};
+  TestCaseVal_int results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("CompOp");
+  CompareTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xi1>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateCompare(param_shape, lhs, rhs, comp_type));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLCompareOperationTest, CompLeOp) {
+  std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> B = {9, 8, 7, 6, 5, 4, 3, 2, 1};
+  std::vector<int8_t> expected_val = {1, 1, 1, 1, 1, 0, 0, 0, 0};
+  auto comp_type = ComparisonDirection::kLe;
+
+  TestCaseVal inputs = {B, A};
+  TestCaseVal_int results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("CompOp");
+  CompareTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xi1>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateCompare(param_shape, lhs, rhs, comp_type));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLCompareOperationTest, CompGtOp) {
+  std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> B = {9, 8, 7, 6, 5, 4, 3, 2, 1};
+  std::vector<int8_t> expected_val = {0, 0, 0, 0, 0, 1, 1, 1, 1};
+  auto comp_type = ComparisonDirection::kGt;
+
+  TestCaseVal inputs = {B, A};
+  TestCaseVal_int results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("CompOp");
+  CompareTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xi1>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateCompare(param_shape, lhs, rhs, comp_type));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLCompareOperationTest, CompGeOp) {
+  std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> B = {9, 8, 7, 6, 5, 4, 3, 2, 1};
+  std::vector<int8_t> expected_val = {0, 0, 0, 0, 1, 1, 1, 1, 1};
+  auto comp_type = ComparisonDirection::kGe;
 
   TestCaseVal inputs = {B, A};
   TestCaseVal_int results = {expected_val};

--- a/tensorflow/compiler/xla/service/plaidml/tests/plaidml_compare_op_test.cc
+++ b/tensorflow/compiler/xla/service/plaidml/tests/plaidml_compare_op_test.cc
@@ -28,18 +28,18 @@ using TestCaseVal = std::vector<std::vector<float>>;
 using TestCaseVal_int = std::vector<std::vector<int8_t>>;
 using TestCasePairs = std::map<TestCaseVal, TestCaseVal_int>;
 
-struct EltwiseTestSpec {
+struct CompareTestSpec {
   PrimitiveType primitive_type;
   string filecheck_lines;
 };
 
-string EltwiseTestSpecToString(const ::testing::TestParamInfo<EltwiseTestSpec>& info) {
+string CompareTestSpecToString(const ::testing::TestParamInfo<CompareTestSpec>& info) {
   return PrimitiveType_Name(info.param.primitive_type);
 }
 
-class PlaidMLEltwiseOperationTest
+class PlaidMLCompareOperationTest
     : public PlaidMLCodegenTest,
-      public ::testing::WithParamInterface<EltwiseTestSpec> {
+      public ::testing::WithParamInterface<CompareTestSpec> {
  protected:
   Status CompileAndCheck(std::unique_ptr<HloComputation> entry_computation,
                          const string& filecheck_lines,
@@ -87,7 +87,7 @@ class PlaidMLEltwiseOperationTest
   }
 };
 
-TEST_P(PlaidMLEltwiseOperationTest, EltwiseCompOp) {
+TEST_P(PlaidMLCompareOperationTest, CompOp) {
   std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
   std::vector<float> B = {9, 8, 7, 6, 5, 4, 3, 2, 1};
   std::vector<int8_t> expected_val = {1, 1, 1, 1, 0, 0, 0, 0, 0};
@@ -99,8 +99,8 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseCompOp) {
   TestCaseVal_int results = {expected_val};
   TestCasePairs testcase_pairs = {{inputs, results}};
 
-  HloComputation::Builder builder("EltwiseCompOp");
-  EltwiseTestSpec spec = GetParam();
+  HloComputation::Builder builder("CompOp");
+  CompareTestSpec spec = GetParam();
 
   auto fcheck_lines = spec.filecheck_lines;
   fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xi1>\n");
@@ -116,8 +116,8 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseCompOp) {
   CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
 }
 
-std::vector<EltwiseTestSpec> GetEltwiseTestCases() {
-  std::vector<EltwiseTestSpec> result;
+std::vector<CompareTestSpec> GetCompareTestCases() {
+  std::vector<CompareTestSpec> result;
 // TODO: reenable F16 when it is ready
 //  result.push_back(
 //      {F16, R"(CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>)"});
@@ -134,9 +134,9 @@ std::vector<EltwiseTestSpec> GetEltwiseTestCases() {
 /**/
 // TODO: INSTANTIATE_TEST_CASE_P was deprecated in favor for INSTANTIATE_TEST_SUITE_P, but the version of gtest that bazel links in is looking for INSTANTIATE_TEST_CASE_P right now.
 INSTANTIATE_TEST_CASE_P(All,
-                         PlaidMLEltwiseOperationTest,
-                         ::testing::ValuesIn(GetEltwiseTestCases()),
-                         EltwiseTestSpecToString);
+                         PlaidMLCompareOperationTest,
+                         ::testing::ValuesIn(GetCompareTestCases()),
+                         CompareTestSpecToString);
 /**/
 }  // namespace
 }  // namespace plaidml

--- a/tensorflow/compiler/xla/service/plaidml/tests/plaidml_compare_op_test.cc
+++ b/tensorflow/compiler/xla/service/plaidml/tests/plaidml_compare_op_test.cc
@@ -1,0 +1,143 @@
+// Tests that show HLO Module conversion to PlaidML Program.
+
+#include <algorithm>
+#include <string>
+#include <map>
+#include <variant>
+
+#include <gtest/gtest.h>
+
+#include "absl/strings/str_cat.h"
+#include "tensorflow/compiler/xla/service/plaidml/compiler.h"
+#include "tensorflow/compiler/xla/service/plaidml/tests/plaidml_codegen_test.h"
+#include "tensorflow/compiler/xla/service/hlo_computation.h"
+#include "tensorflow/compiler/xla/service/hlo_evaluator.h"
+#include "tensorflow/compiler/xla/tests/filecheck.h"
+#include "tensorflow/compiler/xla/tests/test_utils.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/test.h"
+#include "plaidml/testenv.h"
+
+using ::plaidml::edsl::TensorBuffers;
+
+namespace xla {
+namespace plaidml {
+namespace {
+
+using TestCaseVal = std::vector<std::vector<float>>;
+using TestCaseVal_int = std::vector<std::vector<int8_t>>;
+using TestCasePairs = std::map<TestCaseVal, TestCaseVal_int>;
+
+struct EltwiseTestSpec {
+  PrimitiveType primitive_type;
+  string filecheck_lines;
+};
+
+string EltwiseTestSpecToString(const ::testing::TestParamInfo<EltwiseTestSpec>& info) {
+  return PrimitiveType_Name(info.param.primitive_type);
+}
+
+class PlaidMLEltwiseOperationTest
+    : public PlaidMLCodegenTest,
+      public ::testing::WithParamInterface<EltwiseTestSpec> {
+ protected:
+  Status CompileAndCheck(std::unique_ptr<HloComputation> entry_computation,
+                         const string& filecheck_lines,
+                         const TestCasePairs& testcase_pairs) {
+    
+    HloModuleConfig cfg;
+
+    std::unique_ptr<HloModule> hlo_module = absl::make_unique<HloModule>("module", cfg);
+    hlo_module->AddEntryComputation(std::move(entry_computation));
+
+    auto program = CompileToProgram(std::move(hlo_module));
+
+    VLOG(2) << "Program:\n" << program->str();
+
+    StatusOr<bool> fc_result = RunFileCheck(program->str(), filecheck_lines);
+
+    //TF_ASSERT_OK(fc_result.status());
+    EXPECT_TRUE(fc_result.ValueOrDie());
+
+    VLOG(2) << "Evaluating results";
+
+    for (auto pair : testcase_pairs) {
+
+      TensorBuffers inp;
+      TensorBuffers exp;
+
+      auto program_inputs = program->inputs();
+
+      for (auto i = 0; i < program_inputs.size(); i++) {
+        inp.insert(std::make_pair(program_inputs[i].tensor, pair.first[i]));
+      }
+
+      auto program_outputs = program->outputs();
+
+      for (auto i = 0; i < program_outputs.size(); i++) {
+        exp.insert(std::make_pair(program_outputs[i].tensor, pair.second[i]));
+      }
+
+      checkProgram(*program, inp, exp);
+
+    }
+
+    return Status::OK();
+
+  }
+};
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseCompOp) {
+  std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> B = {9, 8, 7, 6, 5, 4, 3, 2, 1};
+  std::vector<int8_t> expected_val = {1, 1, 1, 1, 0, 0, 0, 0, 0};
+  //std::vector<int8_t> expected_val = {0, 0, 0, 0, 1, 0, 0, 0, 0};
+  auto comp_type = ComparisonDirection::kLt;
+  //auto comp_type = ComparisonDirection::kEq;
+
+  TestCaseVal inputs = {B, A};
+  TestCaseVal_int results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseCompOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xi1>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateCompare(param_shape, lhs, rhs, comp_type));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+std::vector<EltwiseTestSpec> GetEltwiseTestCases() {
+  std::vector<EltwiseTestSpec> result;
+// TODO: reenable F16 when it is ready
+//  result.push_back(
+//      {F16, R"(CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>)"});
+  result.push_back({F32, R"#(
+        CHECK: return %{{.*}} : tensor<3x3x{{.*}}>
+        )#"});
+  result.push_back({F64, R"#(
+        CHECK: return %{{.*}} : tensor<3x3x{{.*}}>
+        )#"});
+  return result;
+}
+
+
+/**/
+// TODO: INSTANTIATE_TEST_CASE_P was deprecated in favor for INSTANTIATE_TEST_SUITE_P, but the version of gtest that bazel links in is looking for INSTANTIATE_TEST_CASE_P right now.
+INSTANTIATE_TEST_CASE_P(All,
+                         PlaidMLEltwiseOperationTest,
+                         ::testing::ValuesIn(GetEltwiseTestCases()),
+                         EltwiseTestSpecToString);
+/**/
+}  // namespace
+}  // namespace plaidml
+}  // namespace xla

--- a/tensorflow/compiler/xla/service/plaidml/tests/plaidml_eltwise_op_test.cc
+++ b/tensorflow/compiler/xla/service/plaidml/tests/plaidml_eltwise_op_test.cc
@@ -43,7 +43,7 @@ class PlaidMLEltwiseOperationTest
   Status CompileAndCheck(std::unique_ptr<HloComputation> entry_computation,
                          const string& filecheck_lines,
                          const TestCasePairs& testcase_pairs) {
-
+    
     HloModuleConfig cfg;
 
     std::unique_ptr<HloModule> hlo_module = absl::make_unique<HloModule>("module", cfg);
@@ -86,6 +86,242 @@ class PlaidMLEltwiseOperationTest
   }
 };
 
+//Unary Eltwise Ops
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseAbsOp) {
+  std::vector<float> input_val = {-1, 2, -3, -4, 5, 6, -7, -8, -9};
+  std::vector<float> expected_val = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  TestCaseVal inputs = {input_val};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseAbsOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kAbs, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseCeilOp) {
+  std::vector<float> input_val = {1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9};
+  std::vector<float> expected_val = {2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+  TestCaseVal inputs = {input_val};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseCeilOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kCeil, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseCosOp) {
+  float PI = 3.141592653589;
+  std::vector<float> input_val = {0, PI/3, -PI/3, 2*PI/3, -2*PI/3, 0, 0, PI, -PI};
+  std::vector<float> expected_val = {1, 0.5, 0.5, -0.5, -0.5, 1, 1, -1, -1};
+
+  TestCaseVal inputs = {input_val};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseCosOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kCos, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseExpOp) {
+  std::vector<float> input_val = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> expected_val = {2.7182818, 7.3890561, 20.085537, 54.598150, 148.41316, 
+                                    403.42879, 1096.6332, 2980.9580, 8103.0839};
+
+  TestCaseVal inputs = {input_val};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseExpOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kExp, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseFloorOp) {
+  std::vector<float> input_val = {1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9};
+  std::vector<float> expected_val = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  TestCaseVal inputs = {input_val};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseFloorOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kFloor, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseLogOp) {
+  std::vector<float> input_val = {2.7182818, 7.3890561, 20.085537, 54.598150, 148.41316, 
+                                    403.42879, 1096.6332, 2980.9580, 8103.0839};
+  std::vector<float> expected_val = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  TestCaseVal inputs = {input_val};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseLogOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kLog, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseNegOp) {
+  std::vector<float> input_val = {-1, 2, -3, -4, 5, 6, -7, -8, -9};
+  std::vector<float> expected_val = {1, -2, 3, 4, -5, -6, 7, 8, 9};
+
+  TestCaseVal inputs = {input_val};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseNegOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kNegate, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseRsqrtOp) {
+  std::vector<float> input_val = {1, 4, 9, 16, 25, 36, 49, 64, 81};
+  std::vector<float> expected_val = {1, 0.5, 1.0/3, 0.25, 0.2, 1.0/6, 1.0/7, .125, 1.0/9};
+
+  TestCaseVal inputs = {input_val};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseRsqrtOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kRsqrt, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseSinOp) {
+  float PI = 3.141592653589;
+  std::vector<float> input_val = {0, PI/6, -PI/6, 5*PI/6, -5*PI/6, PI/2, -PI/2, 0, 0};
+  std::vector<float> expected_val = {0, 0.5, -0.5, 0.5, -0.5, 1, -1, 0, 0};
+
+  TestCaseVal inputs = {input_val};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseSinOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kSin, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseSqrtOp) {
+  std::vector<float> input_val = {1, 4, 9, 16, 25, 36, 49, 64, 81};
+  std::vector<float> expected_val = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  TestCaseVal inputs = {input_val};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseSqrtOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kSqrt, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+//Binary Eltwise Ops
 TEST_P(PlaidMLEltwiseOperationTest, EltwiseAddOp) {
   std::vector<float> input_val = {1, 2, 3, 4, 5, 6, 7, 8, 9};
   std::vector<float> expected_val = {2, 4, 6, 8, 10, 12, 14, 16, 18};
@@ -97,6 +333,9 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseAddOp) {
   HloComputation::Builder builder("EltwiseAddOp");
   EltwiseTestSpec spec = GetParam();
 
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
   auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
 
   HloInstruction* lhs = builder.AddInstruction(
@@ -105,20 +344,23 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseAddOp) {
       HloInstruction::CreateParameter(1, param_shape, "input"));
 
   builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kAdd, lhs, rhs));
-  CompileAndCheck(builder.Build(), spec.filecheck_lines, testcase_pairs);
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
 }
 
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseDivOp) {
+  std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> B = {9, 8, 7, 6, 5, 4, 3, 2, 1};
+  std::vector<float> expected_val = {1.0/9, 0.25, 3.0/7, 2.0/3, 1, 1.5, 7.0/3, 4, 9};
 
-TEST_P(PlaidMLEltwiseOperationTest, EltwiseSubOp) {
-  std::vector<float> input_val = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-  std::vector<float> expected_val = {0, 0, 0, 0, 0, 0, 0, 0, 0};
-
-  TestCaseVal inputs = {input_val, input_val};
+  TestCaseVal inputs = {B, A};
   TestCaseVal results = {expected_val};
   TestCasePairs testcase_pairs = {{inputs, results}};
 
-  HloComputation::Builder builder("EltwiseSubOp");
+  HloComputation::Builder builder("EltwiseDivOp");
   EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
 
   auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
 
@@ -127,8 +369,60 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseSubOp) {
   HloInstruction* rhs = builder.AddInstruction(
       HloInstruction::CreateParameter(1, param_shape, "input"));
 
-  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kSubtract, lhs, rhs));
-  CompileAndCheck(builder.Build(), spec.filecheck_lines, testcase_pairs);
+  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kDivide, lhs, rhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseMaxOp) {
+  std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> B = {0, 3, 2, 5, 4, 7, 6, 9, 8};
+  std::vector<float> expected_val = {1, 3, 3, 5, 5, 7, 7, 9, 9};
+
+  TestCaseVal inputs = {A, B};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseMaxOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kMaximum, lhs, rhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseMinOp) {
+  std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> B = {0, 3, 2, 5, 4, 7, 6, 9, 8};
+  std::vector<float> expected_val = {0, 2, 2, 4, 4, 6, 6, 8, 8};
+
+  TestCaseVal inputs = {A, B};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseMinOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kMinimum, lhs, rhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
 }
 
 TEST_P(PlaidMLEltwiseOperationTest, EltwiseMulOp) {
@@ -142,6 +436,9 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseMulOp) {
   HloComputation::Builder builder("EltwiseMulOp");
   EltwiseTestSpec spec = GetParam();
 
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
   auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
 
   HloInstruction* lhs = builder.AddInstruction(
@@ -150,19 +447,23 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseMulOp) {
       HloInstruction::CreateParameter(1, param_shape, "input"));
 
   builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kMultiply, lhs, rhs));
-  CompileAndCheck(builder.Build(), spec.filecheck_lines, testcase_pairs);
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
 }
 
-TEST_P(PlaidMLEltwiseOperationTest, EltwiseDivOp) {
-  std::vector<float> input_val = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-  std::vector<float> expected_val = {1, 1, 1, 1, 1, 1, 1, 1, 1};
+TEST_P(PlaidMLEltwiseOperationTest, EltwisePowOp) {
+  std::vector<float> A = {1, 2, 3, 1, 2, 3, 1, 2, 3};
+  std::vector<float> B = {0, 0, 0, 1, 1, 1, 2, 2, 2};
+  std::vector<float> expected_val = {1, 1, 1, 1, 2, 3, 1, 4, 9};
 
-  TestCaseVal inputs = {input_val, input_val};
+  TestCaseVal inputs = {B, A};
   TestCaseVal results = {expected_val};
   TestCasePairs testcase_pairs = {{inputs, results}};
 
-  HloComputation::Builder builder("EltwiseDivOp");
+  HloComputation::Builder builder("EltwisePowOp");
   EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
 
   auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
 
@@ -171,8 +472,60 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseDivOp) {
   HloInstruction* rhs = builder.AddInstruction(
       HloInstruction::CreateParameter(1, param_shape, "input"));
 
-  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kDivide, lhs, rhs));
-  CompileAndCheck(builder.Build(), spec.filecheck_lines, testcase_pairs);
+  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kPower, lhs, rhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseRemOp) {
+  std::vector<float> A = {10, 10, 10, 10, 10, 10, 10, 10, 10};
+  std::vector<float> B = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> expected_val = {0, 0, 1, 2, 0, 4, 3, 2, 1};
+
+  TestCaseVal inputs = {B, A};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseRemOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kRemainder, lhs, rhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseSubOp) {
+  std::vector<float> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> B = {9, 8, 7, 6, 5, 4, 3, 2, 1};
+  std::vector<float> expected_val = {-8, -6, -4, -2, 0, 2, 4, 6, 8};
+
+  TestCaseVal inputs = {B, A};
+  TestCaseVal results = {expected_val};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseSubOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kSubtract, lhs, rhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
 }
 
 std::vector<EltwiseTestSpec> GetEltwiseTestCases() {
@@ -180,10 +533,12 @@ std::vector<EltwiseTestSpec> GetEltwiseTestCases() {
 // TODO: reenable F16 when it is ready
 //  result.push_back(
 //      {F16, R"(CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>)"});
-  result.push_back(
-      {F32, R"(CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>)"});
-  result.push_back(
-      {F64, R"(CHECK: func @hlo_module(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>)"});
+  result.push_back({F32, R"#(
+        CHECK: return %{{.*}} : tensor<3x3xf32>
+        )#"});
+  result.push_back({F64, R"#(
+        CHECK: return %{{.*}} : tensor<3x3xf32>
+        )#"});
   return result;
 }
 

--- a/tensorflow/compiler/xla/service/plaidml/tests/plaidml_logical_op_test.cc
+++ b/tensorflow/compiler/xla/service/plaidml/tests/plaidml_logical_op_test.cc
@@ -27,18 +27,18 @@ namespace {
 using TestCaseVal = std::vector<std::vector<int>>;
 using TestCasePairs = std::map<TestCaseVal, TestCaseVal>;
 
-struct EltwiseTestSpec {
+struct LogicalTestSpec {
   PrimitiveType primitive_type;
   string filecheck_lines;
 };
 
-string EltwiseTestSpecToString(const ::testing::TestParamInfo<EltwiseTestSpec>& info) {
+string LogicalTestSpecToString(const ::testing::TestParamInfo<LogicalTestSpec>& info) {
   return PrimitiveType_Name(info.param.primitive_type);
 }
 
-class PlaidMLEltwiseOperationTest
+class PlaidMLLogicalOperationTest
     : public PlaidMLCodegenTest,
-      public ::testing::WithParamInterface<EltwiseTestSpec> {
+      public ::testing::WithParamInterface<LogicalTestSpec> {
  protected:
   Status CompileAndCheck(std::unique_ptr<HloComputation> entry_computation,
                          const string& filecheck_lines,
@@ -86,7 +86,7 @@ class PlaidMLEltwiseOperationTest
   }
 };
 
-TEST_P(PlaidMLEltwiseOperationTest, EltwiseAndOp) {
+TEST_P(PlaidMLLogicalOperationTest, LogicalAndOp) {
   std::vector<int> input_A = {0, 0, 1, 1, 0, 0, 1, 1, 0};
   std::vector<int> input_B = {1, 0, 1, 0, 1, 0, 1, 0, 1};
   std::vector<int> output_C = {0, 0, 1, 0, 0, 0, 1, 0, 0};
@@ -95,8 +95,8 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseAndOp) {
   TestCaseVal results = {output_C};
   TestCasePairs testcase_pairs = {{inputs, results}};
 
-  HloComputation::Builder builder("EltwiseAndOp");
-  EltwiseTestSpec spec = GetParam();
+  HloComputation::Builder builder("LogicalAndOp");
+  LogicalTestSpec spec = GetParam();
 
   auto fcheck_lines = spec.filecheck_lines;
   fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xsi32>, %arg1: tensor<3x3xsi32>) -> tensor<3x3xsi32>\n");
@@ -112,7 +112,7 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseAndOp) {
   CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
 }
 
-TEST_P(PlaidMLEltwiseOperationTest, EltwiseNotOp) {
+TEST_P(PlaidMLLogicalOperationTest, LogicalNotOp) {
   std::vector<int> input_A = {0, 0, 1, 1, 0, 0, 1, 1, 0};
   std::vector<int> output_C = {1, 1, 0, 0, 1, 1, 1, 1, 0};
 
@@ -120,8 +120,8 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseNotOp) {
   TestCaseVal results = {output_C};
   TestCasePairs testcase_pairs = {{inputs, results}};
 
-  HloComputation::Builder builder("EltwiseNotOp");
-  EltwiseTestSpec spec = GetParam();
+  HloComputation::Builder builder("LogicalNotOp");
+  LogicalTestSpec spec = GetParam();
 
   auto fcheck_lines = spec.filecheck_lines;
   fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xsi32>) -> tensor<3x3xsi32>\n");
@@ -135,7 +135,7 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseNotOp) {
   CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
 }
 
-TEST_P(PlaidMLEltwiseOperationTest, EltwiseOrOp) {
+TEST_P(PlaidMLLogicalOperationTest, LogicalOrOp) {
   std::vector<int> input_A = {0, 0, 1, 1, 0, 0, 1, 1, 0};
   std::vector<int> input_B = {1, 0, 1, 0, 1, 0, 1, 0, 1};
   std::vector<int> output_C = {1, 0, 1, 1, 1, 0, 1, 1, 1};
@@ -144,8 +144,8 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseOrOp) {
   TestCaseVal results = {output_C};
   TestCasePairs testcase_pairs = {{inputs, results}};
 
-  HloComputation::Builder builder("EltwiseOrOp");
-  EltwiseTestSpec spec = GetParam();
+  HloComputation::Builder builder("LogicalOrOp");
+  LogicalTestSpec spec = GetParam();
 
   auto fcheck_lines = spec.filecheck_lines;
   fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xsi32>, %arg1: tensor<3x3xsi32>) -> tensor<3x3xsi32>\n");
@@ -161,7 +161,7 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseOrOp) {
   CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
 }
 
-TEST_P(PlaidMLEltwiseOperationTest, EltwiseXorOp) {
+TEST_P(PlaidMLLogicalOperationTest, LogicalXorOp) {
   std::vector<int> input_A = {0, 0, 1, 1, 0, 0, 1, 1, 0};
   std::vector<int> input_B = {1, 0, 1, 0, 1, 0, 1, 0, 1};
   std::vector<int> output_C = {1, 0, 0, 1, 1, 0, 0, 1, 1};
@@ -170,8 +170,8 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseXorOp) {
   TestCaseVal results = {output_C};
   TestCasePairs testcase_pairs = {{inputs, results}};
 
-  HloComputation::Builder builder("EltwiseXorOp");
-  EltwiseTestSpec spec = GetParam();
+  HloComputation::Builder builder("LogicalXorOp");
+  LogicalTestSpec spec = GetParam();
 
   auto fcheck_lines = spec.filecheck_lines;
   fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xsi32>, %arg1: tensor<3x3xsi32>) -> tensor<3x3xsi32>\n");
@@ -187,8 +187,8 @@ TEST_P(PlaidMLEltwiseOperationTest, EltwiseXorOp) {
   CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
 }
 
-std::vector<EltwiseTestSpec> GetEltwiseTestCases() {
-  std::vector<EltwiseTestSpec> result;
+std::vector<LogicalTestSpec> GetLogicalTestCases() {
+  std::vector<LogicalTestSpec> result;
   result.push_back(
       {S32, R"#(
         CHECK: return %{{.*}} : tensor<3x3xsi32>
@@ -201,10 +201,10 @@ std::vector<EltwiseTestSpec> GetEltwiseTestCases() {
 
 /**/
 // TODO: INSTANTIATE_TEST_CASE_P was deprecated in favor for INSTANTIATE_TEST_SUITE_P, but the version of gtest that bazel links in is looking for INSTANTIATE_TEST_CASE_P right now.
-INSTANTIATE_TEST_CASE_P(EltwiseAndOp,
-                         PlaidMLEltwiseOperationTest,
-                         ::testing::ValuesIn(GetEltwiseTestCases()),
-                         EltwiseTestSpecToString);
+INSTANTIATE_TEST_CASE_P(LogicalAndOp,
+                         PlaidMLLogicalOperationTest,
+                         ::testing::ValuesIn(GetLogicalTestCases()),
+                         LogicalTestSpecToString);
 /**/
 }  // namespace
 }  // namespace plaidml

--- a/tensorflow/compiler/xla/service/plaidml/tests/plaidml_logical_op_test.cc
+++ b/tensorflow/compiler/xla/service/plaidml/tests/plaidml_logical_op_test.cc
@@ -1,0 +1,211 @@
+// Tests that show HLO Module conversion to PlaidML Program.
+
+#include <algorithm>
+#include <string>
+#include <map>
+#include <variant>
+
+#include <gtest/gtest.h>
+
+#include "absl/strings/str_cat.h"
+#include "tensorflow/compiler/xla/service/plaidml/compiler.h"
+#include "tensorflow/compiler/xla/service/plaidml/tests/plaidml_codegen_test.h"
+#include "tensorflow/compiler/xla/service/hlo_computation.h"
+#include "tensorflow/compiler/xla/service/hlo_evaluator.h"
+#include "tensorflow/compiler/xla/tests/filecheck.h"
+#include "tensorflow/compiler/xla/tests/test_utils.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/test.h"
+#include "plaidml/testenv.h"
+
+using ::plaidml::edsl::TensorBuffers;
+
+namespace xla {
+namespace plaidml {
+namespace {
+
+using TestCaseVal = std::vector<std::vector<int>>;
+using TestCasePairs = std::map<TestCaseVal, TestCaseVal>;
+
+struct EltwiseTestSpec {
+  PrimitiveType primitive_type;
+  string filecheck_lines;
+};
+
+string EltwiseTestSpecToString(const ::testing::TestParamInfo<EltwiseTestSpec>& info) {
+  return PrimitiveType_Name(info.param.primitive_type);
+}
+
+class PlaidMLEltwiseOperationTest
+    : public PlaidMLCodegenTest,
+      public ::testing::WithParamInterface<EltwiseTestSpec> {
+ protected:
+  Status CompileAndCheck(std::unique_ptr<HloComputation> entry_computation,
+                         const string& filecheck_lines,
+                         const TestCasePairs& testcase_pairs) {
+
+    HloModuleConfig cfg;
+
+    std::unique_ptr<HloModule> hlo_module = absl::make_unique<HloModule>("module", cfg);
+    hlo_module->AddEntryComputation(std::move(entry_computation));
+
+    auto program = CompileToProgram(std::move(hlo_module));
+
+    VLOG(2) << "Program:\n" << program->str();
+
+    StatusOr<bool> fc_result = RunFileCheck(program->str(), filecheck_lines);
+
+    //TF_ASSERT_OK(fc_result.status());
+    EXPECT_TRUE(fc_result.ValueOrDie());
+
+    VLOG(2) << "Evaluating results";
+
+    for (auto pair : testcase_pairs) {
+
+      TensorBuffers inp;
+      TensorBuffers exp;
+
+      auto program_inputs = program->inputs();
+
+      for (auto i = 0; i < program_inputs.size(); i++) {
+        inp.insert(std::make_pair(program_inputs[i].tensor, pair.first[i]));
+      }
+
+      auto program_outputs = program->outputs();
+
+      for (auto i = 0; i < program_outputs.size(); i++) {
+        exp.insert(std::make_pair(program_outputs[i].tensor, pair.second[i]));
+      }
+
+      checkProgram(*program, inp, exp);
+
+    }
+
+    return Status::OK();
+
+  }
+};
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseAndOp) {
+  std::vector<int> input_A = {0, 0, 1, 1, 0, 0, 1, 1, 0};
+  std::vector<int> input_B = {1, 0, 1, 0, 1, 0, 1, 0, 1};
+  std::vector<int> output_C = {0, 0, 1, 0, 0, 0, 1, 0, 0};
+
+  TestCaseVal inputs = {input_A, input_B};
+  TestCaseVal results = {output_C};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseAndOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xsi32>, %arg1: tensor<3x3xsi32>) -> tensor<3x3xsi32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kAnd, lhs, rhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseNotOp) {
+  std::vector<int> input_A = {0, 0, 1, 1, 0, 0, 1, 1, 0};
+  std::vector<int> output_C = {1, 1, 0, 0, 1, 1, 1, 1, 0};
+
+  TestCaseVal inputs = {input_A};
+  TestCaseVal results = {output_C};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseNotOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xsi32>) -> tensor<3x3xsi32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateUnary(param_shape, HloOpcode::kNot, lhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseOrOp) {
+  std::vector<int> input_A = {0, 0, 1, 1, 0, 0, 1, 1, 0};
+  std::vector<int> input_B = {1, 0, 1, 0, 1, 0, 1, 0, 1};
+  std::vector<int> output_C = {1, 0, 1, 1, 1, 0, 1, 1, 1};
+
+  TestCaseVal inputs = {input_A, input_B};
+  TestCaseVal results = {output_C};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseOrOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xsi32>, %arg1: tensor<3x3xsi32>) -> tensor<3x3xsi32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kOr, lhs, rhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+TEST_P(PlaidMLEltwiseOperationTest, EltwiseXorOp) {
+  std::vector<int> input_A = {0, 0, 1, 1, 0, 0, 1, 1, 0};
+  std::vector<int> input_B = {1, 0, 1, 0, 1, 0, 1, 0, 1};
+  std::vector<int> output_C = {1, 0, 0, 1, 1, 0, 0, 1, 1};
+
+  TestCaseVal inputs = {input_A, input_B};
+  TestCaseVal results = {output_C};
+  TestCasePairs testcase_pairs = {{inputs, results}};
+
+  HloComputation::Builder builder("EltwiseXorOp");
+  EltwiseTestSpec spec = GetParam();
+
+  auto fcheck_lines = spec.filecheck_lines;
+  fcheck_lines.insert(4,"CHECK: func @hlo_module(%arg0: tensor<3x3xsi32>, %arg1: tensor<3x3xsi32>) -> tensor<3x3xsi32>\n");
+
+  auto param_shape = ShapeUtil::MakeShape(spec.primitive_type, {3, 3});
+
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, param_shape, "input"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, param_shape, "input"));
+
+  builder.AddInstruction(HloInstruction::CreateBinary(param_shape, HloOpcode::kXor, lhs, rhs));
+  CompileAndCheck(builder.Build(), fcheck_lines, testcase_pairs);
+}
+
+std::vector<EltwiseTestSpec> GetEltwiseTestCases() {
+  std::vector<EltwiseTestSpec> result;
+  result.push_back(
+      {S32, R"#(
+        CHECK: return %{{.*}} : tensor<3x3xsi32>
+        )#"});
+  // TODO: Determine issue with si64 testing
+  return result;
+}
+
+
+
+/**/
+// TODO: INSTANTIATE_TEST_CASE_P was deprecated in favor for INSTANTIATE_TEST_SUITE_P, but the version of gtest that bazel links in is looking for INSTANTIATE_TEST_CASE_P right now.
+INSTANTIATE_TEST_CASE_P(EltwiseAndOp,
+                         PlaidMLEltwiseOperationTest,
+                         ::testing::ValuesIn(GetEltwiseTestCases()),
+                         EltwiseTestSpecToString);
+/**/
+}  // namespace
+}  // namespace plaidml
+}  // namespace xla

--- a/tensorflow/compiler/xla/service/plaidml/tests/plaidml_logical_op_test.cc
+++ b/tensorflow/compiler/xla/service/plaidml/tests/plaidml_logical_op_test.cc
@@ -113,8 +113,12 @@ TEST_P(PlaidMLLogicalOperationTest, LogicalAndOp) {
 }
 
 TEST_P(PlaidMLLogicalOperationTest, LogicalNotOp) {
-  std::vector<int> input_A = {0, 0, 1, 1, 0, 0, 1, 1, 0};
-  std::vector<int> output_C = {1, 1, 0, 0, 1, 1, 1, 1, 0};
+  std::vector<int> input_A =  {static_cast<int>(0x00000000), static_cast<int>(0x11111111), static_cast<int>(0x22222222), //
+                               static_cast<int>(0x33333333), static_cast<int>(0x44444444), static_cast<int>(0x55555555), //
+                               static_cast<int>(0xDDDDDDDD), static_cast<int>(0xEEEEEEEE), static_cast<int>(0xFFFFFFFF)};
+  std::vector<int> output_C = {static_cast<int>(0xFFFFFFFF), static_cast<int>(0xEEEEEEEE), static_cast<int>(0xDDDDDDDD), //
+                               static_cast<int>(0xCCCCCCCC), static_cast<int>(0xBBBBBBBB), static_cast<int>(0xAAAAAAAA), //
+                               static_cast<int>(0x22222222), static_cast<int>(0x11111111), static_cast<int>(0x00000000)};
 
   TestCaseVal inputs = {input_A};
   TestCaseVal results = {output_C};


### PR DESCRIPTION
Added test for operations requiring integer inputs (namely, logical operations)
Modified styling of tests a bit to allow for operation-specific lit test checks (as well as checks applied to all operations in the file):

Currently, the tested ops (And, Or, Xor, Not) each have one basic input/output comparison, a lit test checking the function specification (operation-specific) and a lit test checking the function output (applied to all tests).

Not() currently does not pass the test; it looks like the outputs for that op are offset by -2 for some reason (if that is actually the intended output of not I will change the test appropriately).