### PR TITLE
Update plaidml, resnext/i3d tests

### DIFF
--- a/tensorflow/compiler/xla/service/plaidml/tests/BUILD
+++ b/tensorflow/compiler/xla/service/plaidml/tests/BUILD
@@ -115,7 +115,7 @@ tf_cc_test(
 
 tf_cc_test(
     name = "plaidml_i3d_test",
-    srcs = ["plaidml_i3d_test.cc"],
+    srcs = ["plaidml_i3d_test.cc", "i3d_pretrained_inputs_and_weights.h"],
     extra_copts = ["-fexceptions"],
     deps = [
         "//tensorflow/compiler/xla/service:hlo",

--- a/tensorflow/compiler/xla/service/plaidml/tests/plaidml_resnext_test.cc
+++ b/tensorflow/compiler/xla/service/plaidml/tests/plaidml_resnext_test.cc
@@ -60,14 +60,26 @@ class PlaidMLResNeXTOperationTest
       TensorBuffers exp;
 
       auto program_inputs = program->inputs();
+      auto tcp_inputs = pair.first;
+
+      if (tcp_inputs.size() != program_inputs.size()) {
+        VLOG(1) << "Found mismatch in input sizes: tcp " << tcp_inputs.size() << " program " << program_inputs.size();
+      }
 
       for (auto i = 0; i < program_inputs.size(); i++) {
+        VLOG(1) << "Adding TestCaseInput " << i;
         inp.insert(std::make_pair(program_inputs[i].tensor, pair.first[i]));
       }
 
       auto program_outputs = program->outputs();
+      auto tcp_outputs = pair.second;
+
+      if (tcp_outputs.size() != program_outputs.size()) {
+        VLOG(1) << "Found mismatch in output sizes: tcp " << tcp_outputs.size() << " program " << program_outputs.size();
+      }
 
       for (auto i = 0; i < program_outputs.size(); i++) {
+        VLOG(1) << "Adding TestCaseOutput " << i;
         exp.insert(std::make_pair(program_outputs[i].tensor, pair.second[i]));
       }
 
@@ -76,15 +88,13 @@ class PlaidMLResNeXTOperationTest
       checkProgram(*program, inp, exp);
 
     }
-
     return Status::OK();
-
   }
 };
 
 TEST_P(PlaidMLResNeXTOperationTest, SimpleResNeXT) {
 
-TestCaseVal ResNeXt50_WeightsInputs = {{0}, ::weights::stage4_unit3_bn3_mean, ::weights::stage4_unit3_bn3_scale, ::weights::stage4_unit3_bn3_var, {2e-05}, //
+TestCaseVal ResNeXt50_WeightsInputs = {{0}, {0}, ::weights::stage4_unit3_bn3_mean, ::weights::stage4_unit3_bn3_scale, ::weights::stage4_unit3_bn3_var, {2e-05}, //
  ::weights::stage4_unit3_bn3_bias, ::weights::stage4_unit3_conv3_weight, {0}, ::weights::stage4_unit3_bn2_mean, ::weights::stage4_unit3_bn2_scale, {2e-05}, //
  ::weights::stage4_unit3_bn2_var, ::weights::stage4_unit3_bn2_bias, ::weights::stage4_unit3_conv2_weight, {0}, ::weights::stage4_unit3_bn1_mean, ::weights::stage4_unit3_bn1_scale, {2e-05}, //
  ::weights::stage4_unit3_bn1_var, ::weights::stage4_unit3_bn1_bias, ::weights::stage4_unit3_conv1_weight, {0}, ::weights::stage4_unit2_bn3_mean, ::weights::stage4_unit2_bn3_scale, {2e-05}, //
@@ -136,7 +146,7 @@ TestCaseVal ResNeXt50_WeightsInputs = {{0}, ::weights::stage4_unit3_bn3_mean, ::
  ::weights::stage3_unit1_bn3_var, ::weights::stage3_unit1_bn3_bias, ::weights::stage3_unit1_conv3_weight, {0}, ::weights::stage3_unit1_bn2_mean, ::weights::stage3_unit1_bn2_scale, {2e-05}, //
  ::weights::stage3_unit1_bn2_var, ::weights::stage3_unit1_bn2_bias, ::weights::stage3_unit1_conv2_weight, {0}, ::weights::stage3_unit1_bn1_mean, ::weights::stage3_unit1_bn1_scale, {2e-05}, //
  ::weights::stage3_unit1_bn1_var, ::weights::stage3_unit1_bn1_bias, ::weights::stage3_unit1_conv1_weight, ::weights::stage4_unit1_bn3_mean, ::weights::stage4_unit1_bn3_scale, {2e-05}, //
- ::weights::stage4_unit1_bn3_var , ::weights::stage4_unit1_bn3_bias, ::weights::stage4_unit1_conv3_weight, {0}, ::weights::stage4_unit1_bn2_mean, ::weights::stage4_unit1_bn2_scale, {2e-05}, //
+ ::weights::stage4_unit1_bn3_var, ::weights::stage4_unit1_bn3_bias, ::weights::stage4_unit1_conv3_weight, {0}, ::weights::stage4_unit1_bn2_mean, ::weights::stage4_unit1_bn2_scale, {2e-05}, //
  ::weights::stage4_unit1_bn2_var, ::weights::stage4_unit1_bn2_bias, ::weights::stage4_unit1_conv2_weight, {0}, ::weights::stage4_unit1_bn1_mean, ::weights::stage4_unit1_bn1_scale, {2e-05}, //
  ::weights::stage4_unit1_bn1_var, ::weights::stage4_unit1_bn1_bias, ::weights::stage4_unit1_conv1_weight};
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -657,8 +657,8 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     )
 
     # Check out LLVM and MLIR from llvm-project.
-    LLVM_COMMIT = "3149709e7f809405a861f4460c7c2aaf98ba350c"
-    LLVM_SHA256 = "7c9ae29375d3bc2e84f890b035197cab417a8393b28fdf561713108e30703e95"
+    LLVM_COMMIT = "f00f71b2a279449c04796e28b3b7bb0e06c945bf"
+    LLVM_SHA256 = "88fccbb163aac6192d572ce3ed1538a2f6e4eb9341c529ecccba502bb2f0d144"
     LLVM_URLS = [
         "https://storage.googleapis.com/mirror.tensorflow.org/github.com/plaidml/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
         "https://github.com/plaidml/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),

--- a/third_party/plaidml/workspace.bzl
+++ b/third_party/plaidml/workspace.bzl
@@ -6,9 +6,9 @@ def clean_dep(dep):
 def repo():
     http_archive(
         name = "com_intel_plaidml",
-        url = "https://github.com/plaidml/plaidml/archive/39b55f858e4f0a2415e8c8f1a5f141021dc5cc93.zip",
-        sha256 = "25424e779944bd67d748bd7f790a3ca3a364eebf23197f9f72d7338447e0098b",
-        strip_prefix = "plaidml-39b55f858e4f0a2415e8c8f1a5f141021dc5cc93",
+        url = "https://github.com/plaidml/plaidml/archive/c0c3e376d9e00eff751753ea2ba89ce413ce7cd7.zip",
+        sha256 = "d51c4529e480c28c2b35a5c82a5c47e7c557a875720e5bf9a4a641d42bee8a91",
+        strip_prefix = "plaidml-c0c3e376d9e00eff751753ea2ba89ce413ce7cd7",
     )
     http_archive(
         name = "gflags",


### PR DESCRIPTION
* Update `plaidml` and `llvm-project` pointers to match latest plaidml-v1 commit
* Fix bad spacing/formatting chars in resnext test that was causing runtime inconsistencies
* Added input/weight based evaluation to i3d test

Both resnext/i3d now consistently segfault at the same place due to the buffer -> memref issue which is still being debugged in main plaidml.

**NOTE**: Currently, `i3d_pretrained_inputs_and_weights.h` and `resnext50_pretrained_inputs_and_weights.h` are not a part of the repository due to size (GBs). I will need to eventually address how to pull in weights in C++ for the full-sized network tests, but I have the files available locally and that is what I'm currently working with.